### PR TITLE
chore: clean dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-gelreportmodels",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2370,7 +2370,49 @@
     "@types/double-ended-queue": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.0.tgz",
-      "integrity": "sha512-pCS41/Odn6GMQyqnt8aPTSTQFGriAryYQwVONKk1QhUEhulxueLPE1kDNqDOuJqiv34VLVWXxF4I1EKz3+ftzQ=="
+      "integrity": "sha512-pCS41/Odn6GMQyqnt8aPTSTQFGriAryYQwVONKk1QhUEhulxueLPE1kDNqDOuJqiv34VLVWXxF4I1EKz3+ftzQ==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "*"
+      }
+    },
+    "@types/highlight.js": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -2406,7 +2448,8 @@
     "@types/js-combinatorics": {
       "version": "0.5.29",
       "resolved": "https://registry.npmjs.org/@types/js-combinatorics/-/js-combinatorics-0.5.29.tgz",
-      "integrity": "sha1-R6eBmgtpJbbcS9LCJ4p+Yymyk4c="
+      "integrity": "sha1-R6eBmgtpJbbcS9LCJ4p+Yymyk4c=",
+      "dev": true
     },
     "@types/jsonfile": {
       "version": "5.0.0",
@@ -2420,7 +2463,14 @@
     "@types/lodash": {
       "version": "4.14.116",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
-      "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg=="
+      "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
+      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -2433,6 +2483,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.0.tgz",
       "integrity": "sha512-dmYIvoQEZWnyQfgrwPCoxztv/93NYQGEiOoQhuI56rJahv9de6Q2apZl3bufV46YJ0OAXdaktIuw4RIRl4DTeA==",
       "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.6.tgz",
+      "integrity": "sha512-svx2eQS268awlppL/P8wgDLBrsDXdKznABHJcuqXyWpSKJgE1s2clXlBvAwbO/lehTmG06NtEWJRkAk4tAgenA==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -2636,15 +2696,6 @@
         "find-up": "^3.0.0",
         "istanbul-lib-instrument": "^3.0.0",
         "test-exclude": "^5.0.0"
-      }
-    },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dev": true,
-      "requires": {
-        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -3482,22 +3533,16 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.2.0",
+        "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -5373,12 +5418,6 @@
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
       "dev": true
     },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-      "dev": true
-    },
     "js-combinatorics": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.3.tgz",
@@ -5463,7 +5502,8 @@
     "json2typescript": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/json2typescript/-/json2typescript-1.0.6.tgz",
-      "integrity": "sha512-9xRrXy3B783kZc2czj+OuZTfOfVluMMkLkOHBSfxZ5XQudp6fviov5KLfX4madfrrlTaqLvjNTXkNkskIXU8Uw=="
+      "integrity": "sha512-9xRrXy3B783kZc2czj+OuZTfOfVluMMkLkOHBSfxZ5XQudp6fviov5KLfX4madfrrlTaqLvjNTXkNkskIXU8Uw==",
+      "dev": true
     },
     "json5": {
       "version": "2.1.0",
@@ -5574,12 +5614,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lunr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
-      "dev": true
-    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -5620,9 +5654,9 @@
       }
     },
     "marked": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
-      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
       "dev": true
     },
     "micromatch": {
@@ -6899,48 +6933,49 @@
       }
     },
     "typedoc": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.6.tgz",
-      "integrity": "sha512-TC3j7HXFfyq0/NyUL9oLgEXhgO4U8Kd7iyRgagkG3XxehgTjn6w20uJ/Hif1KPB/65VQZ8uMYYyxFXNj9um5Ow==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
+      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
       "dev": true,
       "requires": {
+        "@types/fs-extra": "^5.0.3",
+        "@types/handlebars": "^4.0.38",
+        "@types/highlight.js": "^9.12.3",
+        "@types/lodash": "^4.14.110",
+        "@types/marked": "^0.4.0",
         "@types/minimatch": "3.0.3",
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.5.3",
-        "highlight.js": "^9.17.1",
-        "lodash": "^4.17.15",
-        "marked": "^0.8.0",
+        "@types/shelljs": "^0.8.0",
+        "fs-extra": "^7.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.13.1",
+        "lodash": "^4.17.10",
+        "marked": "^0.4.0",
         "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.3",
-        "typescript": "3.7.x"
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.2",
+        "typedoc-default-themes": "^0.5.0",
+        "typescript": "3.2.x"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-          "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz",
-      "integrity": "sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==",
-      "dev": true,
-      "requires": {
-        "backbone": "^1.4.0",
-        "jquery": "^3.4.1",
-        "lunr": "^2.3.8",
-        "underscore": "^1.9.1"
-      }
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+      "dev": true
     },
     "typescript": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg=="
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.7.4",
@@ -6961,12 +6996,6 @@
           "optional": true
         }
       }
-    },
-    "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
-      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ts-gelreportmodels",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "GelReportModels TypeScript classes",
-  "main": "index.ts",
+  "main": "index.js",
   "scripts": {
     "test": "jest",
     "build": "rm -Rf ./dist && tsc --build tsconfig.json"
@@ -14,21 +14,21 @@
   "author": "Genomics England",
   "license": "Private",
   "dependencies": {
-    "@types/double-ended-queue": "^2.1.0",
-    "@types/js-combinatorics": "^0.5.29",
-    "@types/lodash": "^4.14.116",
     "double-ended-queue": "^2.1.0-0",
     "js-combinatorics": "^0.5.3",
-    "json2typescript": "^1.0.6",
-    "lodash": "^4.17.15",
-    "typescript": "3.0.1"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@types/jest": "^23.3.1",
     "@types/jsonfile": "^5.0.0",
+    "@types/double-ended-queue": "^2.1.0",
+    "@types/js-combinatorics": "^0.5.29",
+    "@types/lodash": "^4.14.116",
     "jest": "^24.1.0",
     "jsonfile": "^5.0.0",
     "ts-jest": "^24.0.0",
-    "typedoc": "^0.15.6"
+    "typedoc": "^0.14.2",
+    "typescript": "3.0.1",
+    "json2typescript": "^1.0.6"
   }
 }


### PR DESCRIPTION
Move typescript + related stuff to devDependencies.
Dependency size of this repo dropped from 88mb to 4mb.